### PR TITLE
Fix normalizing an exception that wraps a throwable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0"
+    "ext-json": "*",
+    "php": ">=7.2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "8.*",
     "codeclimate/php-test-reporter": "dev-master",
     "codacy/coverage": "dev-master"
   },
@@ -34,5 +35,8 @@
     "psr-4": {
       "InterfaSys\\LogNormalizer\\": "src/"
     }
+  },
+  "scripts": {
+    "test": "phpunit -c phpunit.xml"
   }
 }

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -14,6 +14,8 @@
 
 namespace InterfaSys\LogNormalizer;
 
+use Throwable;
+
 /**
  * Converts any variable to a String
  *
@@ -252,7 +254,7 @@ class Normalizer {
 	 */
 	private function normalizeObject($data, $depth) {
 		if (is_object($data)) {
-			if ($data instanceof \Exception) {
+			if ($data instanceof Throwable) {
 				return $this->normalizeException($data);
 			}
 			// We don't need to go too deep in the recursion
@@ -275,11 +277,11 @@ class Normalizer {
 	/**
 	 * Converts an Exception to String
 	 *
-	 * @param \Exception $exception
+	 * @param Throwable $exception
 	 *
 	 * @return string[]
 	 */
-	private function normalizeException(\Exception $exception) {
+	private function normalizeException(Throwable $exception) {
 		$data = [
 			'class'   => get_class($exception),
 			'message' => $exception->getMessage(),

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -15,17 +15,22 @@
 
 namespace InterfaSys\LogNormalizer;
 
+use Exception;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+use function get_class;
+
 /**
  * @covers InterfaSys\LogNormalizer\Normalizer
  */
-class NormalizerTest extends \PHPUnit_Framework_TestCase {
+class NormalizerTest extends TestCase {
 
 	/**
 	 * @var Normalizer
 	 */
 	protected $normalizer;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		$this->normalizer = new Normalizer();
 	}
 
@@ -36,28 +41,29 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		$data = "Don't underestimate the power of the string [+*%&]";
 		$formatted = $this->normalizer->format($data);
 
-		$this->assertEquals("Don't underestimate the power of the string [+*%&]", $formatted);
+		self::assertEquals("Don't underestimate the power of the string [+*%&]", $formatted);
 	}
 
 	public function testBoolean() {
 		$data = true;
 		$normalized = $this->normalizer->normalize($data);
 
-		$this->assertTrue($normalized);
+		self::assertTrue($normalized);
 
 		$formatted = $this->normalizer->convertToString($normalized);
 
-		$this->assertEquals('true', $formatted);
+		self::assertEquals('true', $formatted);
 	}
 
 	public function testFloat() {
 		$data = 3.14413;
 		$normalized = $this->normalizer->normalize($data);
-		$this->assertEquals(3.14413, $normalized);
+		self::assertIsFloat($normalized);
 
 		$formatted = $this->normalizer->convertToString($normalized);
 
-		$this->assertEquals('3.14413', $formatted);
+		self::assertIsString($formatted);
+		self::assertEquals(3.14413, $formatted);
 	}
 
 	public function testInfinity() {
@@ -67,18 +73,18 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		];
 		$normalized = $this->normalizer->normalize($data);
 
-		$this->assertEquals($data, $normalized);
+		self::assertEquals($data, $normalized);
 
 		$formatted = $this->normalizer->convertToString($normalized);
 
-		$this->assertEquals('{"inf":"INF","-inf":"-INF"}', $formatted);
+		self::assertEquals('{"inf":"INF","-inf":"-INF"}', $formatted);
 	}
 
 	public function testNan() {
 		$data = acos(4);
 		$normalized = $this->normalizer->normalize($data);
 
-		$this->assertEquals('NaN', $normalized);
+		self::assertEquals('NaN', $normalized);
 	}
 
 	public function testSimpleObject() {
@@ -88,12 +94,12 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		$expectedResult = [
 			'[object] (InterfaSys\\LogNormalizer\\TestFooNorm)' => ['foo' => 'foo']
 		];
-		$this->assertEquals($expectedResult, $normalized);
+		self::assertEquals($expectedResult, $normalized);
 
 		$formatted = $this->normalizer->convertToString($normalized);
 		$expectedString = '{"[object] (InterfaSys\\LogNormalizer\\TestFooNorm)":{"foo":"foo"}}';
 
-		$this->assertEquals($expectedString, $formatted);
+		self::assertEquals($expectedString, $formatted);
 	}
 
 	public function testLongArray() {
@@ -103,11 +109,10 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		$normalizer = new Normalizer(4, 20);
 		$normalized = $normalizer->normalize($data);
 
-
 		$expectedResult = array_slice($data, 0, 19);
 		$expectedResult['...'] = 'Over 20 items, aborting normalization';
 
-		$this->assertEquals($expectedResult, $normalized);
+		self::assertEquals($expectedResult, $normalized);
 	}
 
 	public function testArrayWithObject() {
@@ -127,7 +132,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			'[object] (' . $objectFooName . ')' => ['foo' => 'foo']
 		];
 
-		$this->assertEquals($objectFooResult, $normalized['foo']);
+		self::assertEquals($objectFooResult, $normalized['foo']);
 
 		$expectedResult = [
 			"foo" => $objectFooResult,
@@ -136,7 +141,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 				true
 			]
 		];
-		$this->assertEquals($expectedResult, $normalized);
+		self::assertEquals($expectedResult, $normalized);
 
 		$formatted = $this->normalizer->convertToString($normalized);
 		$objectFooName = get_class($objectFoo);
@@ -144,7 +149,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		$expectedString =
 			'{"foo":' . $objectFooResult . ',"baz":["quz",true]}';
 
-		$this->assertEquals($expectedString, $formatted);
+		self::assertEquals($expectedString, $formatted);
 	}
 
 	public function testUnlimitedObjectRecursion() {
@@ -166,7 +171,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			'[object] (' . $objectFooName . ')' => ['foo' => 'foo']
 		];
 
-		$this->assertEquals(
+		self::assertEquals(
 			$objectFooResult, $normalized['[object] (' . $objectMainName . ')']['foo']
 		);
 
@@ -177,7 +182,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		$this->assertEquals(
+		self::assertEquals(
 			$objectBarResult, $normalized['[object] (' . $objectMainName . ')']['bar']
 		);
 
@@ -189,7 +194,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		$this->assertEquals(
+		self::assertEquals(
 			$objectBazResult, $normalized['[object] (' . $objectMainName . ')']['baz']
 		);
 
@@ -202,7 +207,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		$this->assertEquals($objectMainResult, $normalized);
+		self::assertEquals($objectMainResult, $normalized);
 	}
 
 	public function testLimitedObjectRecursion() {
@@ -224,7 +229,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			'[object] (' . $objectFooName . ')' => ['foo' => 'foo']
 		];
 
-		$this->assertEquals(
+		self::assertEquals(
 			$objectFooResult, $normalized['[object] (' . $objectMainName . ')']['foo']
 		);
 
@@ -236,7 +241,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		$this->assertEquals(
+		self::assertEquals(
 			$objectBarResult, $normalized['[object] (' . $objectMainName . ')']['bar']
 		);
 
@@ -250,7 +255,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		$this->assertEquals(
+		self::assertEquals(
 			$objectBazResult, $normalized['[object] (' . $objectMainName . ')']['baz']
 		);
 
@@ -263,7 +268,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 			]
 		];
 
-		$this->assertEquals($objectMainResult, $normalized);
+		self::assertEquals($objectMainResult, $normalized);
 	}
 
 	public function testDate() {
@@ -271,7 +276,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		$data = new \DateTime;
 		$normalized = $normalizer->normalize($data);
 
-		$this->assertEquals(date('Y-m-d'), $normalized);
+		self::assertEquals(date('Y-m-d'), $normalized);
 	}
 
 	public function testResource() {
@@ -279,7 +284,7 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		$resourceId = (int)$data;
 		$normalized = $this->normalizer->normalize($data);
 
-		$this->assertEquals('[resource] Resource id #' . $resourceId, $normalized);
+		self::assertEquals('[resource] Resource id #' . $resourceId, $normalized);
 	}
 
 	public function testFormatExceptions() {
@@ -290,10 +295,10 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		];
 		$normalized = $this->normalizer->normalize($data);
 
-		$this->assertTrue(isset($normalized['exception']['previous']));
+		self::assertTrue(isset($normalized['exception']['previous']));
 		unset($normalized['exception']['previous']);
 
-		$this->assertEquals(
+		self::assertEquals(
 			[
 				'exception' => [
 					'class'   => get_class($e2),
@@ -306,12 +311,41 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testFormatExceptionWithPreviousThrowable() {
+		$t = new TypeError("not a type error");
+		$e = new Exception("an exception", 13, $t);
+
+		$normalized = $this->normalizer->normalize([
+			'exception' => $e,
+		]);
+
+		self::assertEquals(
+			[
+				'exception' => [
+					'class'   => get_class($e),
+					'message' => $e->getMessage(),
+					'code'    => $e->getCode(),
+					'file'    => $e->getFile() . ':' . $e->getLine(),
+					'trace'   => $e->getTraceAsString(),
+					'previous' => [
+						'class' => 'TypeError',
+						'message' => 'not a type error',
+						'code' => 0,
+						'file' => $t->getFile() . ':' . $t->getLine(),
+						'trace' => $t->getTraceAsString(),
+					]
+				]
+			], $normalized
+		);
+		self::assertTrue(isset($normalized['exception']['previous']));
+	}
+
 	public function testUnknown() {
 		$data = fopen('php://memory', 'rb');
 		fclose($data);
 		$normalized = $this->normalizer->normalize($data);
 
-		$this->assertEquals('[unknown(' . gettype($data) . ')]', $normalized);
+		self::assertEquals('[unknown(' . gettype($data) . ')]', $normalized);
 	}
 }
 


### PR DESCRIPTION
If you pass an exception to the lib it normalizes it. If you pass an exception that wraps another exception is normalizes those as well.

But if you pass an exception that wraps a throwable things go :boom: 

So, I fixed that. Then I couldn't verify it via a unit tests because I can't run this old version of phpstorm anymore. Updated php and phpstorm. Had to fix some float magic with php and the new phpunit.

It all passes now and the original issue is resolved.

There are loads of other things to clean up, but I tried to keep the change relatively small. Still turned out bigger than expected.

Original error from Nextcloud:

<details>

```
{
   "reqId":"APoApKeQY4igZ9PJFEfm",
   "level":3,
   "time":"2020-11-30T14:04:10+00:00",
   "remoteAddr":"xxxxxxxxxx",
   "user":"alex.podaru",
   "app":"index",
   "method":"GET",
   "url":"/apps/mail/api/messages?mailboxId=7&limit=20",
   "message":{
      "Exception":"TypeError",
      "Message":"Argument 1 passed to InterfaSys\\LogNormalizer\\Normalizer::normalizeException() must be an instance of Exception, instance of TypeError given, called in /cloud/3rdparty/interfasys/lognormalizer/src/Normalizer.php on line 294",
      "Code":0,
      "Trace":[
         {
            "file":"/cloud/3rdparty/interfasys/lognormalizer/src/Normalizer.php",
            "line":294,
            "function":"normalizeException",
            "class":"InterfaSys\\LogNormalizer\\Normalizer",
            "type":"->"
         },
         {
            "file":"/cloud/3rdparty/interfasys/lognormalizer/src/Normalizer.php",
            "line":256,
            "function":"normalizeException",
            "class":"InterfaSys\\LogNormalizer\\Normalizer",
            "type":"->"
         },
         {
            "function":"normalizeObject",
            "class":"InterfaSys\\LogNormalizer\\Normalizer",
            "type":"->"
         },
         {
            "file":"/cloud/3rdparty/interfasys/lognormalizer/src/Normalizer.php",
            "line":100,
            "function":"call_user_func_array"
         },
         {
            "file":"/cloud/3rdparty/interfasys/lognormalizer/src/Normalizer.php",
            "line":68,
            "function":"normalize",
            "class":"InterfaSys\\LogNormalizer\\Normalizer",
            "type":"->"
         },
         {
            "function":"format",
            "class":"InterfaSys\\LogNormalizer\\Normalizer",
            "type":"->"
         },
         {
            "file":"/cloud/lib/private/Log.php",
            "line":324,
            "function":"array_walk"
         },
         {
            "file":"/cloud/lib/private/Log/PsrLoggerAdapter.php",
            "line":136,
            "function":"logException",
            "class":"OC\\Log",
            "type":"->"
         },
         {
            "file":"/cloud/lib/private/AppFramework/ScopedPsrLogger.php",
            "line":89,
            "function":"error",
            "class":"OC\\Log\\PsrLoggerAdapter",
            "type":"->"
         },
         {
            "file":"/cloud/apps/mail/lib/Http/Middleware/ErrorMiddleware.php",
            "line":101,
            "function":"error",
            "class":"OC\\AppFramework\\ScopedPsrLogger",
            "type":"->"
         },
         {
            "file":"/cloud/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php",
            "line":122,
            "function":"afterException",
            "class":"OCA\\Mail\\Http\\Middleware\\ErrorMiddleware",
            "type":"->"
         },
         {
            "file":"/cloud/lib/private/AppFramework/Http/Dispatcher.php",
            "line":112,
            "function":"afterException",
            "class":"OC\\AppFramework\\Middleware\\MiddlewareDispatcher",
            "type":"->"
         },
         {
            "file":"/cloud/lib/private/AppFramework/App.php",
            "line":152,
            "function":"dispatch",
            "class":"OC\\AppFramework\\Http\\Dispatcher",
            "type":"->"
         },
         {
            "file":"/cloud/lib/private/Route/Router.php",
            "line":308,
            "function":"main",
            "class":"OC\\AppFramework\\App",
            "type":"::"
         },
         {
            "file":"/cloud/lib/base.php",
            "line":1008,
            "function":"match",
            "class":"OC\\Route\\Router",
            "type":"->"
         },
         {
            "file":"/cloud/index.php",
            "line":37,
            "function":"handleRequest",
            "class":"OC",
            "type":"::"
         }
      ],
      "File":"/cloud/3rdparty/interfasys/lognormalizer/src/Normalizer.php",
      "Line":282,
      "CustomMessage":"--"
   },
   "userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36",
   "version":"20.0.2.2"
}
```

</details>

@oparoz please review :)